### PR TITLE
Use sdcard location from Environment

### DIFF
--- a/app/src/main/java/com/micewine/emu/activities/MainActivity.kt
+++ b/app/src/main/java/com/micewine/emu/activities/MainActivity.kt
@@ -10,6 +10,7 @@ import android.content.IntentFilter
 import android.content.SharedPreferences
 import android.os.Build
 import android.os.Bundle
+import android.os.Environment.getExternalStorageDirectory
 import android.os.storage.StorageManager
 import android.view.ContextMenu
 import android.view.KeyEvent
@@ -1035,7 +1036,7 @@ class MainActivity : AppCompatActivity() {
                 val driveC = File("$winePrefix/drive_c")
                 val wineUtils = File("$appRootDir/wine-utils")
                 val startMenu = File("$driveC/ProgramData/Microsoft/Windows/Start Menu")
-                val userSharedFolder = File("/storage/emulated/0/MiceWine")
+                val userSharedFolder = File(getExternalStorageDirectory(), "MiceWine")
                 val localAppData = File("$driveC/users/$unixUsername/AppData")
                 val system32 = File("$driveC/windows/system32")
                 val syswow64 = File("$driveC/windows/syswow64")

--- a/app/src/main/java/com/micewine/emu/fragments/FloatingFileManagerFragment.kt
+++ b/app/src/main/java/com/micewine/emu/fragments/FloatingFileManagerFragment.kt
@@ -6,6 +6,7 @@ import android.app.Dialog
 import android.content.DialogInterface
 import android.content.Intent
 import android.os.Bundle
+import android.os.Environment.getExternalStorageDirectory
 import android.util.Log
 import android.view.View
 import android.widget.EditText
@@ -43,7 +44,7 @@ class FloatingFileManagerFragment(private val operationType: Int) : DialogFragme
         recyclerView  = view.findViewById(R.id.recyclerViewFiles)
         recyclerView?.adapter = AdapterFiles(fileList, requireContext(), true)
 
-        fileManagerCwd = "/storage/emulated/0"
+        fileManagerCwd = externalStorageDir
 
         refreshFiles(operationType)
 
@@ -144,6 +145,7 @@ class FloatingFileManagerFragment(private val operationType: Int) : DialogFragme
     }
 
     companion object {
+        private val externalStorageDir by lazy { getExternalStorageDirectory().absolutePath }
         private var recyclerView: RecyclerView? = null
         private val fileList: MutableList<AdapterFiles.FileList> = mutableListOf()
         var calledSetup: Boolean = false
@@ -158,7 +160,7 @@ class FloatingFileManagerFragment(private val operationType: Int) : DialogFragme
 
             fileList.clear()
 
-            if (fileManagerCwd != "/storage/emulated/0") {
+            if (fileManagerCwd != externalStorageDir) {
                 addToAdapter(File(".."))
             }
 


### PR DESCRIPTION
#### What
This fixes an issue where the file selector could not be used with a secondary user profile on android. The primary user's storage might usually be in `/storage/emulated/0/`, but a secondary user might have their storage in `/storage/emulated/10/` for example. This is because each **user has isolated storage**.

Using `Environment` will ensure the correct path is resolved. See documentation for [getExternalStorageDirectory](https://developer.android.com/reference/android/os/Environment#getExternalStorageDirectory()).

#### Why
If you use this application together with [island](https://github.com/oasisfeng/island), secure folder, work profile, etc, the filepicker will open but it will be completely unusable. This is because some of the hard coded path assumptions will break when trying to access the secondary user's isolated storage.

#### Example

[before]: https://github.com/user-attachments/assets/19fe626f-2ca3-401f-a76b-3a0a2d66df61
[after]: https://github.com/user-attachments/assets/898bbf61-75f8-4cb3-a982-ae451afa2f3c

| Before    | After    |
|-----------|----------|
| ![before] | ![after] |

