### PR TITLE
Add 18:9 Aspect Ratio

### DIFF
--- a/app/src/main/java/com/micewine/emu/activities/MainActivity.java
+++ b/app/src/main/java/com/micewine/emu/activities/MainActivity.java
@@ -1311,6 +1311,14 @@ public class MainActivity extends AppCompatActivity {
             "3840x2160", "7680x4320"
     };
 
+    public static String[] resolutions18_9 = new String[] {
+            "720x360", "960x480",
+            "1080x540", "1440x720",
+            "1536x768", "1800x900",
+            "20160x1080", "2880x1440",
+            "4320x2160", "8640x4320"
+    };
+    
     public static String[] resolutions4_3 = new String[] {
             "640x480", "800x600",
             "1024x768", "1280x960",

--- a/app/src/main/java/com/micewine/emu/fragments/EditGamePreferencesFragment.java
+++ b/app/src/main/java/com/micewine/emu/fragments/EditGamePreferencesFragment.java
@@ -8,6 +8,7 @@ import static com.micewine.emu.activities.MainActivity.ACTION_SELECT_ICON;
 import static com.micewine.emu.activities.MainActivity.getNativeResolutions;
 import static com.micewine.emu.activities.MainActivity.preferences;
 import static com.micewine.emu.activities.MainActivity.resolutions16_9;
+import static com.micewine.emu.activities.MainActivity.resolutions18_9;
 import static com.micewine.emu.activities.MainActivity.resolutions4_3;
 import static com.micewine.emu.activities.MainActivity.selectedCpuAffinity;
 import static com.micewine.emu.activities.MainActivity.usrDir;
@@ -444,6 +445,7 @@ public class EditGamePreferencesFragment extends DialogFragment {
 
                 switch (selectedItem) {
                     case "16:9" -> resolutions = Arrays.asList(resolutions16_9);
+                    case "18:9" -> resolutions = Arrays.asList(resolutions18_9);
                     case "4:3" -> resolutions = Arrays.asList(resolutions4_3);
                     case "Native" -> resolutions = getNativeResolutions(requireActivity());
                     default -> resolutions = List.of();
@@ -797,7 +799,7 @@ public class EditGamePreferencesFragment extends DialogFragment {
     public final static int EDIT_GAME_PREFERENCES = 0;
     public final static int FILE_MANAGER_START_PREFERENCES = 1;
 
-    public static List<String> aspectRatios = List.of("16:9", "4:3", "Native");
+    public static List<String> aspectRatios = List.of("16:9", "18:9", "4:3", "Native");
     public static List<String> d3dxRenderers = List.of("DXVK", "WineD3D");
     private static final TemporarySettings temporarySettings = new TemporarySettings();
 


### PR DESCRIPTION
This adds the 18:9 Aspect Ratio to MiceWine. This is my favorite Aspect Ratio, because the camera punch hole doesn't cover it and the screen is still centered.
<img width="1079" height="617" alt="Screenshot_2025-07-30-23-00-21-991_com micewine emu" src="https://github.com/user-attachments/assets/ff33b366-e369-47ef-93f4-2b9055da0499" />
![Screenshot_2025-07-30-22-48-18-484_com micewine emu](https://github.com/user-attachments/assets/19ffcae9-8288-47dc-a0d0-c6e121a1a236)
